### PR TITLE
Add colorful azaleas to the minecraft:saplings tag

### DIFF
--- a/Common/src/main/resources/data/minecraft/tags/blocks/saplings.json
+++ b/Common/src/main/resources/data/minecraft/tags/blocks/saplings.json
@@ -1,0 +1,12 @@
+{
+  "replace": false,
+  "values": [
+    "colorfulazaleas:orange_azalea_sapling",
+    "colorfulazaleas:yellow_azalea_sapling",
+    "colorfulazaleas:red_azalea_sapling",
+    "colorfulazaleas:blue_azalea_sapling",
+    "colorfulazaleas:pink_azalea_sapling",
+    "colorfulazaleas:purple_azalea_sapling",
+    "colorfulazaleas:white_azalea_sapling"
+  ]
+}


### PR DESCRIPTION
The vanilla ones are in there, so it seems like these ought to be.